### PR TITLE
GitHub URI Parameters

### DIFF
--- a/cmd/cmd_github.go
+++ b/cmd/cmd_github.go
@@ -41,7 +41,7 @@ func cmdGitHub(cmd *flag.FlagSet) {
 	db := database.GetDB(neo4jURI, neo4jUser, neo4jPassword)
 
 	// Now we can actually call the ingestor
-	gh := github.GetGitHub(db, *githubApiURI, *githubGraphQlURI, *githubToken, organization, session)
+	gh := github.GetGitHub(db, *githubRESTURL, *githubGraphQLURL, *githubToken, organization, session)
 	gh.SyncByIngestorNames(ingestorNames)
 }
 

--- a/cmd/cmd_github.go
+++ b/cmd/cmd_github.go
@@ -41,7 +41,7 @@ func cmdGitHub(cmd *flag.FlagSet) {
 	db := database.GetDB(neo4jURI, neo4jUser, neo4jPassword)
 
 	// Now we can actually call the ingestor
-	gh := github.GetGitHub(db, *githubToken, organization, session)
+	gh := github.GetGitHub(db, githubApiURI, githubGraphQlURI, *githubToken, organization, session)
 	gh.SyncByIngestorNames(ingestorNames)
 }
 

--- a/cmd/cmd_github.go
+++ b/cmd/cmd_github.go
@@ -41,7 +41,7 @@ func cmdGitHub(cmd *flag.FlagSet) {
 	db := database.GetDB(neo4jURI, neo4jUser, neo4jPassword)
 
 	// Now we can actually call the ingestor
-	gh := github.GetGitHub(db, githubApiURI, githubGraphQlURI, *githubToken, organization, session)
+	gh := github.GetGitHub(db, *githubApiURI, *githubGraphQlURI, *githubToken, organization, session)
 	gh.SyncByIngestorNames(ingestorNames)
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,8 @@ var (
 
 	githubCmd        = flag.NewFlagSet("github", flag.ExitOnError)
 	githubToken      = githubCmd.String("token", "", "The GitHub access token.")
-	githubRESTURL    = githubCmd.String("github-rest-url", "https://api.github.com", "The target GitHub API URL, defaults to https://api.github.com.")
-	githubGraphQLURL = githubCmd.String("github-graphql-url", "https://api.github.com/graphql", "The target GitHub GraphQL URL, defaults to https://api.github.com/graphql.")
+	githubRESTURL    = githubCmd.String("github-rest-url", "https://api.github.com", "The target GitHub API URL.")
+	githubGraphQLURL = githubCmd.String("github-graphql-url", "https://api.github.com/graphql", "The target GitHub GraphQL URL.")
 	githubIngestors  arrayFlags
 
 	circleCICmd    = flag.NewFlagSet("circleci", flag.ExitOnError)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,18 +13,18 @@ import (
 
 var (
 	// Common parameters for all commands
-	debug            bool
-	organization     string
-	neo4jURI         string
-	neo4jUser        string
-	neo4jPassword    string
-	session          string
-	githubApiURI     string
-	githubGraphQlURI string
+	debug         bool
+	organization  string
+	neo4jURI      string
+	neo4jUser     string
+	neo4jPassword string
+	session       string
 
-	githubCmd       = flag.NewFlagSet("github", flag.ExitOnError)
-	githubToken     = githubCmd.String("token", "", "The GitHub access token.")
-	githubIngestors arrayFlags
+	githubCmd        = flag.NewFlagSet("github", flag.ExitOnError)
+	githubToken      = githubCmd.String("token", "", "The GitHub access token.")
+	githubApiURI     = githubCmd.String("github-api-uri", "https://api.github.com", "The target GitHub API URI, defaults to https://api.github.com; Change if targeting Github Enterprise.")
+	githubGraphQlURI = githubCmd.String("github-graphql-uri", "https://api.github.com/graphql", "The target GitHub GraphQL URI, defaults to https://api.github.com/graphql; Change if targeting Github Enterprise.")
+	githubIngestors  arrayFlags
 
 	circleCICmd    = flag.NewFlagSet("circleci", flag.ExitOnError)
 	circleCICookie = circleCICmd.String(
@@ -110,8 +110,6 @@ func setupCommonFlags() {
 		fs.StringVar(&neo4jURI, "neo4j-uri", "neo4j://localhost:7687", "The Neo4j URI.")
 		fs.StringVar(&neo4jUser, "neo4j-user", "neo4j", "The Neo4j user.")
 		fs.StringVar(&neo4jPassword, "neo4j-password", "", "The Neo4j password.")
-		fs.StringVar(&githubApiURI, "github-api-uri","https://api.github.com", "The target GitHub API URI, defaults to https://api.github.com; Change if targeting Github Enterprise.")
-		fs.StringVar(&githubGraphQlURI, "github-graphql-uri","https://api.github.com/graphql", "The target GitHub GraphQL URI, defaults to https://api.github.com/graphql; Change if targeting Github Enterprise.")
 		fs.StringVar(
 			&session,
 			"session",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,8 @@ var (
 
 	githubCmd        = flag.NewFlagSet("github", flag.ExitOnError)
 	githubToken      = githubCmd.String("token", "", "The GitHub access token.")
-	githubApiURI     = githubCmd.String("github-api-uri", "https://api.github.com", "The target GitHub API URI, defaults to https://api.github.com; Change if targeting Github Enterprise.")
-	githubGraphQlURI = githubCmd.String("github-graphql-uri", "https://api.github.com/graphql", "The target GitHub GraphQL URI, defaults to https://api.github.com/graphql; Change if targeting Github Enterprise.")
+	githubRESTURL    = githubCmd.String("github-rest-url", "https://api.github.com", "The target GitHub API URL, defaults to https://api.github.com.")
+	githubGraphQLURL = githubCmd.String("github-graphql-url", "https://api.github.com/graphql", "The target GitHub GraphQL URL, defaults to https://api.github.com/graphql.")
 	githubIngestors  arrayFlags
 
 	circleCICmd    = flag.NewFlagSet("circleci", flag.ExitOnError)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,12 +13,14 @@ import (
 
 var (
 	// Common parameters for all commands
-	debug         bool
-	organization  string
-	neo4jURI      string
-	neo4jUser     string
-	neo4jPassword string
-	session       string
+	debug            bool
+	organization     string
+	neo4jURI         string
+	neo4jUser        string
+	neo4jPassword    string
+	session          string
+	githubApiURI     string
+	githubGraphQlURI string
 
 	githubCmd       = flag.NewFlagSet("github", flag.ExitOnError)
 	githubToken     = githubCmd.String("token", "", "The GitHub access token.")
@@ -108,6 +110,8 @@ func setupCommonFlags() {
 		fs.StringVar(&neo4jURI, "neo4j-uri", "neo4j://localhost:7687", "The Neo4j URI.")
 		fs.StringVar(&neo4jUser, "neo4j-user", "neo4j", "The Neo4j user.")
 		fs.StringVar(&neo4jPassword, "neo4j-password", "", "The Neo4j password.")
+		fs.StringVar(&githubApiURI, "github-api-uri","https://api.github.com", "The target GitHub API URI, defaults to https://api.github.com; Change if targeting Github Enterprise.")
+		fs.StringVar(&githubGraphQlURI, "github-graphql-uri","https://api.github.com/graphql", "The target GitHub GraphQL URI, defaults to https://api.github.com/graphql; Change if targeting Github Enterprise.")
 		fs.StringVar(
 			&session,
 			"session",

--- a/docs/run.md
+++ b/docs/run.md
@@ -78,7 +78,7 @@ The following ingestors need to run first and in this particular order:
 
 Order doesn't matter for other ingestors.
 
-#### Github Enterprise
+#### GitHub Enterprise
 
 If you are targeting GitHub Enterprise, you will want to set the `-github-api-uri` and `-github-graphql-uri` parameters, as they default to `https://github.com` style URIs.
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -78,6 +78,24 @@ The following ingestors need to run first and in this particular order:
 
 Order doesn't matter for other ingestors.
 
+#### Github Enterprise
+
+If you are targeting GitHub Enterprise, you will want to set the `-github-api-uri` and `-github-graphql-uri` parameters, as they default to `https://github.com` style URIs.
+
+```
+$ gitoops github                                                    \
+          -debug                                                    \
+          -github-api-uri="https://git.ent.example/api/v3"          \
+          -github-graphql-uri="https://git.ent.example/api/graphql" \
+          -organization fakenews                                    \
+          -neo4j-password $NEO4J_PASSWORD                           \
+          -neo4j-uri="neo4j://localhost:7687"                       \
+          -token $GITHUB_TOKEN                                      \
+          -ingestor default                                         \
+          -ingestor secrets                                         \
+          -session helloworld
+```
+
 ### Ingest CircleCI data
 
 Unfortunately, the documented CircleCI REST API doesn't give everything we want. Luckily there's a "hidden" GraphQL API we can access with a cookie. With your browser, navigate to the CircleCI web UI and fetch your `ring-session` cookie. You should be able to find this in a request to the `graphql-unstable` endpoint when loading some pages.

--- a/docs/run.md
+++ b/docs/run.md
@@ -78,23 +78,9 @@ The following ingestors need to run first and in this particular order:
 
 Order doesn't matter for other ingestors.
 
-#### GitHub Enterprise
+#### GitHub Enterprise Server
 
-If you are targeting GitHub Enterprise, you will want to set the `-github-api-uri` and `-github-graphql-uri` parameters, as they default to `https://github.com` style URIs.
-
-```
-$ gitoops github                                                    \
-          -debug                                                    \
-          -github-api-uri="https://git.ent.example/api/v3"          \
-          -github-graphql-uri="https://git.ent.example/api/graphql" \
-          -organization fakenews                                    \
-          -neo4j-password $NEO4J_PASSWORD                           \
-          -neo4j-uri="neo4j://localhost:7687"                       \
-          -token $GITHUB_TOKEN                                      \
-          -ingestor default                                         \
-          -ingestor secrets                                         \
-          -session helloworld
-```
+If you are targetting a self-hosted GitHub Enterprise Server, you will want to set the `-github-rest-url` and `-github-graphql-url` parameters. These default to the GitHub cloud URLs.
 
 ### Ingest CircleCI data
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -14,15 +14,17 @@ type GitHub struct {
 	session    string
 }
 
-func GetGitHub(db *database.Database, token, organization, session string) *GitHub {
+func GetGitHub(db *database.Database, githubApiURI, githubGraphQlURI, token, organization, session string) *GitHub {
 	return &GitHub{
 		gqlclient: &GraphQLClient{
 			client:       &http.Client{},
+			githubGraphQlURI:    githubGraphQlURI,
 			token:        token,
 			organization: organization,
 		},
 		restclient: &RESTClient{
 			client:       &http.Client{},
+			githubApiURI:    githubApiURI,
 			token:        token,
 			organization: organization,
 		},

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -17,16 +17,16 @@ type GitHub struct {
 func GetGitHub(db *database.Database, githubRESTURL, githubGraphQLURL, token, organization, session string) *GitHub {
 	return &GitHub{
 		gqlclient: &GraphQLClient{
-			client:       &http.Client{},
-			githubGraphQlURI:    githubGraphQlURI,
-			token:        token,
-			organization: organization,
+			client:           &http.Client{},
+			githubGraphQLURL: githubGraphQLURL,
+			token:            token,
+			organization:     organization,
 		},
 		restclient: &RESTClient{
-			client:       &http.Client{},
-			githubApiURI:    githubApiURI,
-			token:        token,
-			organization: organization,
+			client:        &http.Client{},
+			githubRESTURL: githubRESTURL,
+			token:         token,
+			organization:  organization,
 		},
 		db:      db,
 		session: session,

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -14,7 +14,7 @@ type GitHub struct {
 	session    string
 }
 
-func GetGitHub(db *database.Database, githubApiURI, githubGraphQlURI, token, organization, session string) *GitHub {
+func GetGitHub(db *database.Database, githubRESTURL, githubGraphQLURL, token, organization, session string) *GitHub {
 	return &GitHub{
 		gqlclient: &GraphQLClient{
 			client:       &http.Client{},

--- a/pkg/github/graphql_client.go
+++ b/pkg/github/graphql_client.go
@@ -20,10 +20,10 @@ var (
 )
 
 type GraphQLClient struct {
-	client              *http.Client
-	token               string
-	organization        string
-	githubGraphQLURL    string
+	client           *http.Client
+	token            string
+	organization     string
+	githubGraphQLURL string
 }
 
 type GraphQLError struct {

--- a/pkg/github/graphql_client.go
+++ b/pkg/github/graphql_client.go
@@ -23,6 +23,7 @@ type GraphQLClient struct {
 	client       *http.Client
 	token        string
 	organization string
+	githubGraphQlURI    string
 }
 
 type GraphQLError struct {
@@ -45,7 +46,7 @@ func (c *GraphQLClient) call(query string, variables map[string]string) []byte {
 
 	req, err := http.NewRequest(
 		"POST",
-		"https://api.github.com/graphql",
+		c.githubGraphQlURI,
 		bytes.NewBuffer(jsonValue),
 	)
 	if err != nil {

--- a/pkg/github/graphql_client.go
+++ b/pkg/github/graphql_client.go
@@ -20,10 +20,10 @@ var (
 )
 
 type GraphQLClient struct {
-	client       *http.Client
-	token        string
-	organization string
-	githubGraphQlURI    string
+	client              *http.Client
+	token               string
+	organization        string
+	githubGraphQLURL    string
 }
 
 type GraphQLError struct {
@@ -46,7 +46,7 @@ func (c *GraphQLClient) call(query string, variables map[string]string) []byte {
 
 	req, err := http.NewRequest(
 		"POST",
-		c.githubGraphQlURI,
+		c.githubGraphQLURL,
 		bytes.NewBuffer(jsonValue),
 	)
 	if err != nil {

--- a/pkg/github/rest_client.go
+++ b/pkg/github/rest_client.go
@@ -12,10 +12,10 @@ import (
 )
 
 type RESTClient struct {
-	client       *http.Client
-	token        string
-	organization string
-	githubApiURI string
+	client        *http.Client
+	token         string
+	organization  string
+	githubRESTURL string
 }
 
 type RESTError struct {
@@ -28,7 +28,7 @@ type RESTError struct {
 func (c *RESTClient) call(resourcePath string, page int) (int, []byte) {
 	log.Debugf("Issuing REST query %s page %d", resourcePath, page)
 
-	u, _ := url.Parse(c.githubApiURI)
+	u, _ := url.Parse(c.githubRESTURL)
 	u.Path = path.Join(u.Path, resourcePath)
 	req, err := http.NewRequest(
 		"GET",

--- a/pkg/github/rest_client.go
+++ b/pkg/github/rest_client.go
@@ -15,6 +15,7 @@ type RESTClient struct {
 	client       *http.Client
 	token        string
 	organization string
+	githubApiURI string
 }
 
 type RESTError struct {
@@ -27,7 +28,7 @@ type RESTError struct {
 func (c *RESTClient) call(resourcePath string, page int) (int, []byte) {
 	log.Debugf("Issuing REST query %s page %d", resourcePath, page)
 
-	u, _ := url.Parse("https://api.github.com")
+	u, _ := url.Parse(c.githubApiURI)
 	u.Path = path.Join(u.Path, resourcePath)
 	req, err := http.NewRequest(
 		"GET",

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -10,16 +10,16 @@ import (
 )
 
 var (
-	githubToken   = os.Getenv("GITHUB_TOKEN")
-	githubApiURI  = "https://api.github.com"
-	githubGraphQlURI = "https://api.github.com/graphql"
-	neo4jURI      = "neo4j://localhost:7687"
-	neo4jUser     = "neo4j"
-	neo4jPassword = "neo4j" // ignore
-	organization  = os.Getenv("GITHUB_ORGANIZATION")
-	session       = "e2e"
-	db            = database.GetDB(neo4jURI, neo4jUser, neo4jPassword)
-	ingestors     = []string{
+	githubToken      = os.Getenv("GITHUB_TOKEN")
+	githubRESTURL    = "https://api.github.com"
+	githubGraphQLURL = "https://api.github.com/graphql"
+	neo4jURI         = "neo4j://localhost:7687"
+	neo4jUser        = "neo4j"
+	neo4jPassword    = "neo4j" // ignore
+	organization     = os.Getenv("GITHUB_ORGANIZATION")
+	session          = "e2e"
+	db               = database.GetDB(neo4jURI, neo4jUser, neo4jPassword)
+	ingestors        = []string{
 		"organizations",
 		"teams",
 		"users",
@@ -87,7 +87,7 @@ func runTestCase(tc testCase, t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	gh := github.GetGitHub(db, githubApiURI, githubGraphQlURI, githubToken, organization, session)
+	gh := github.GetGitHub(db, githubRESTURL, githubGraphQLURL, githubToken, organization, session)
 	gh.SyncByIngestorNames(ingestors)
 	exitVal := m.Run()
 	os.Exit(exitVal)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -11,6 +11,8 @@ import (
 
 var (
 	githubToken   = os.Getenv("GITHUB_TOKEN")
+	githubApiURI  = "https://api.github.com"
+	githubGraphQlURI = "https://api.github.com/graphql"
 	neo4jURI      = "neo4j://localhost:7687"
 	neo4jUser     = "neo4j"
 	neo4jPassword = "neo4j" // ignore
@@ -85,7 +87,7 @@ func runTestCase(tc testCase, t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	gh := github.GetGitHub(db, githubToken, organization, session)
+	gh := github.GetGitHub(db, githubApiURI, githubGraphQlURI, githubToken, organization, session)
 	gh.SyncByIngestorNames(ingestors)
 	exitVal := m.Run()
 	os.Exit(exitVal)


### PR DESCRIPTION
* Introduced two parameters to set custom GitHub Enterprise URIs: -github-api-uri, -github-graphql-uri
* Updated documentation to reflect the new parameters

Parameters default to Github.com URIs and are optional.